### PR TITLE
Add ability to add, remove and list workflows

### DIFF
--- a/ptool
+++ b/ptool
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 # Project Tool
 # Author: Arnav Gosain <arn4v@outlook.com>
 # Version: 0.1
@@ -23,126 +24,139 @@ parser.add_argument(
 parser.add_argument("-lw", "--list-workflows", action="store_true")
 
 
-class Helper:
-    def __init__(self):
-        self.config_dir = os.path.join(
-            os.environ["HOME"],
-            "AppData\\Local\\ptool"
-            if platform.system() == "Windows"
-            else ".config/ptool",
-        )
-        self.config_fpath = os.path.join(self.config_dir, "ptool.config.json")
+config_dir = os.path.join(
+    os.environ["HOME"],
+    "AppData\\Local\\ptool" if platform.system() == "Windows" else ".config/ptool",
+)
+config_fpath = os.path.join(config_dir, "ptool.config.json")
 
-        if not os.path.exists(self.config_dir):
-            os.mkdir(self.config_dir)
+if not os.path.exists(config_dir):
+    os.mkdir(config_dir)
 
-        if not os.path.exists(self.config_fpath):
-            with open(self.config_fpath, "w") as conf:
-                conf.write(json.dumps({"workflows": ""}, indent=4))
+if not os.path.exists(config_fpath):
+    with open(config_fpath, "w") as conf:
+        conf.write(json.dumps({"workflows": ""}, indent=4))
 
-        self.configuration = json.load(open(self.config_fpath, "r"))
+configuration = json.load(open(config_fpath, "r"))
 
-    def __mkdircd__(self, path: str) -> NoReturn:
+
+def mkdircd(path: str) -> NoReturn:
+    if not os.path.exists(path):
         os.mkdir(path)
         os.chdir(path)
+    else:
+        sys.exit(path + " already exists.")
 
-    def __write_config__(self, new_config: dict):
-        with open(self.config_fpath, "w") as conf:
-            conf.write(json.dumps(new_config, indent=4))
 
-    def list_workflows(self):
-        for workflow in self.configuration["workflows"]:
-            print(workflow["name"])
+def write_config(new_config: dict):
+    with open(config_fpath, "w") as conf:
+        conf.write(json.dumps(new_config, indent=4))
 
-    def add_workflow(self):
-        conf = self.configuration
-        workflows = conf["workflows"]
-        workflow_name = input("Enter workflow name: ")
-        workflow_alias = input("Alias workflow an alias (Leave it empty if not): ")
-        workflow_extends = input(
-            "Does this workflow extend a pre-existing workflow? (Leave it empty if not): "
-        )
-        workflow_commands = list()
-        while True:
-            command = input("Enter new command (Leave empty to exit): ")
-            if len(command) >= 1:
-                workflow_commands.append(command)
-            else:
-                break
-        workflows.append(
-            {
-                "name": workflow_name,
-                "alias": workflow_alias,
-                "extends": workflow_extends,
-                "commands": workflow_commands,
-            }
-        )
-        conf["workflows"] = workflows
-        self.__write_config__(new_config=conf)
 
-    def delete_workflow(self, name: str):
-        conf = self.configuration
-        workflows = conf["workflows"]
-        names = [wf["name"] for wf in workflows]
-        if name in names:
-            workflows.pop(names.index(name))
+def list_workflows():
+    for workflow in configuration["workflows"]:
+        print(workflow["name"])
+
+
+def add_workflow():
+    conf = configuration
+    workflows = conf["workflows"]
+    workflow_name = input("Enter workflow name: ")
+    workflow_alias = input("Alias workflow an alias (Leave it empty if not): ")
+    workflow_extends = input(
+        "Does this workflow extend a pre-existing workflow? (Leave it empty if not): "
+    )
+    workflow_commands = list()
+    while True:
+        command = input("Enter new command (Leave empty to exit): ")
+        if len(command) >= 1:
+            workflow_commands.append(command)
         else:
-            print(
-                name + " not a valid workflow. Run ptool -lw to see existing workflows."
+            break
+    workflows.append(
+        {
+            "name": workflow_name,
+            "alias": workflow_alias,
+            "extends": workflow_extends,
+            "commands": workflow_commands,
+        }
+    )
+    conf["workflows"] = workflows
+    write_config(new_config=conf)
+
+
+def delete_workflow(name: str):
+    conf = configuration
+    workflows = conf["workflows"]
+    names = [wf["name"] for wf in workflows]
+    if name in names:
+        workflows.pop(names.index(name))
+    else:
+        print(name + " not a valid workflow. Run ptool -lw to see existing workflows.")
+    conf["workflows"] = workflows
+    write_config(new_config=conf)
+
+
+def init_script(path: str, runtime: str) -> NoReturn:
+    path = os.path.abspath(path)
+    with open(path, "w") as script:
+        shebang = f"#!/usr/bin/env {runtime}"
+        script.write(shebang)
+        script.close()
+    print("Created script skeleton at " + path)
+
+
+def init_project(path: str, workflow: str) -> NoReturn:
+    path = os.path.abspath(path)
+    names = [wf["name"] for wf in configuration["workflows"]]
+
+    mkdircd(path)
+    if workflow in names:
+        wf = configuration["workflows"][names.index(workflow)]
+        print("Initiating new project in " + path)
+        try:
+            if wf["extends"] in names:
+                print("Running " + wf["extends"] + " commands!")
+                for command in configuration["workflows"][names.index(wf["extends"])][
+                    "commands"
+                ]:
+                    subprocess.run(
+                        shlex.split(command),
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                    )
+
+        except:
+            pass
+
+        print("Running " + wf["name"] + " commands!")
+        for command in wf["commands"]:
+            subprocess.run(
+                shlex.split(command), stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
-        conf["workflows"] = workflows
-        self.__write_config__(new_config=conf)
-
-    def init_script(self, path: str, runtime: str) -> NoReturn:
-        path = os.path.abspath(path)
-        with open(self.path, "w") as script:
-            shebang = f"#!/usr/bin/env {runtime}"
-            script.write(shebang)
-            script.close()
-        print("Created script skeleton at " + self.path)
-
-    def init_project(self, path: str, workflow: str) -> NoReturn:
-        path = os.path.abspath(path)
-        configuration = self.configuration
-        names = [wf["name"] for wf in configuration["workflows"]]
-
-        self.__mkdircd__(path)
-        if workflow in names:
-            wf = configuration["workflows"][names.index(workflow)]
-            try:
-                if wf["extends"] in names:
-                    for command in configuration["workflows"][
-                        names.index(wf["extends"])
-                    ]["commands"]:
-                        subprocess.run(shlex.split(command))
-            except:
-                pass
-
-            print("Initiating new project in " + path)
-            for command in wf["commands"]:
-                subprocess.run(shlex.split(command))
+        
+        print('Done 🎉')
 
 
 def main():
     args = parser.parse_args()
-    helper_instance = Helper()
     if args.create != None and len(args.create) <= 3:
         if args.create[0] == "script":
-            helper_instance.init_script(path=args.create[2], runtime=args.create[1])
+            init_script(path=args.create[2], runtime=args.create[1])
         elif args.create[0] == "project":
-            helper_instance.init_project(path=args.create[2], workflow=args.create[1])
+            init_project(path=args.create[2], workflow=args.create[1])
         else:
             sys.exit(
                 args.create[0] + "is not a valid type. Valid types: project, script"
             )
     elif args.append_license:
-        helper_instance.list_workflows()
+        list_workflows()
     elif args.list_workflows:
-        helper_instance.list_workflows()
+        list_workflows()
     elif args.add_workflow:
-        helper_instance.add_workflow()
+        add_workflow()
     elif args.delete_workflow != None and len(args.delete_workflow) >= 1:
-        helper_instance.delete_workflow(args.delete_workflow)
+        delete_workflow(args.delete_workflow)
     elif len(sys.argv) == 1:
         parser.print_help(sys.stderr)
         sys.exit(1)

--- a/ptool
+++ b/ptool
@@ -24,10 +24,7 @@ parser.add_argument("-lw", "--list-workflows", action="store_true")
 
 
 class Helper:
-    def __init__(self, path: str, language: str, config: dict):
-        self.path = os.path.abspath(path)
-        self.lang = language
-
+    def __init__(self):
         self.config_dir = os.path.join(
             os.environ["HOME"],
             "AppData\\Local\\ptool"
@@ -45,42 +42,33 @@ class Helper:
 
         self.configuration = json.load(open(self.config_fpath, "r"))
 
-    def __mkdircd__(self) -> NoReturn:
-        os.mkdir(self.path)
-        os.chdir(self.path)
-
-    def __isvalid__(self, type: int):
-        configuration = self.configuration
-        # type 1 is create_script, type 2 is project
-        for workflow in configuration["workflows"]:
-            if self.lang == workflow["name"] or self.lang == workflow["alias"]:
-                if type == 1:
-                    return True, workflow["name"], workflow["runtime"]
-                elif type == 2:
-                    return True, workflow["name"], workflow["commands"]
+    def __mkdircd__(self, path: str) -> NoReturn:
+        os.mkdir(path)
+        os.chdir(path)
 
     def __write_config__(self, new_config: dict):
         with open(self.config_fpath, "w") as conf:
             conf.write(json.dumps(new_config, indent=4))
 
-    def init_script(self) -> NoReturn:
+    def init_script(self, path: str, runtime: str) -> NoReturn:
+        path = os.path.abspath(path)
         print("Creating new script")
-        lang_valid, language, runtime = self.__isvalid__(type=1)
-        if lang_valid:
-            with open(self.path, "w") as script:
-                shebang = f"#!/usr/bin/env {runtime}"
-                script.write(shebang)
-                script.close()
-            print("Created script skeleton at " + self.path)
+        with open(self.path, "w") as script:
+            shebang = f"#!/usr/bin/env {runtime}"
+            script.write(shebang)
+            script.close()
+        print("Created script skeleton at " + self.path)
 
-    def init_project(self) -> NoReturn:
+    def init_project(self, path: str, workflow: str) -> NoReturn:
         print("Creating new script")
-        lang_valid, language, language_commands = self.__isvalid__(type=2)
-        if lang_valid:
-            print("Initiating new project in " + self.path)
-            self.__mkdircd__()
-            for command in language_commands:
-                subprocess.run(shlex.split(command))
+        configuration = self.configuration
+        # type 1 is create_script, type 2 is project
+        for workflow in configuration["workflows"]:
+            if workflow == workflow["name"] or workflow == workflow["alias"]:
+                print("Initiating new project in " + self.path)
+                self.__mkdircd__(path)
+                for command in workflow["commands"]:
+                    subprocess.run(shlex.split(command))
 
     def list_workflows(self):
         for workflow in self.configuration["workflows"]:
@@ -125,24 +113,25 @@ class Helper:
 def main():
     types = ["script", "project"]
     args = parser.parse_args()
-    config_helper_instance = ConfigHelper()
-    config = ConfigHelper().read_config()
+    helper_instance = Helper()
     if args.create != None and len(args.create) <= 3:
-        c_type, c_path, c_lang = args.create[0], args.create[1], args.create[2]
         if args.create[0] in types:
-            helper_instance = Helper(path=c_path, language=c_lang, config=config)
-            if c_type == "script":
-                helper_instance.init_script()
-            elif c_type == "project":
-                helper_instance.init_project()
+            if args.create[0] == "script":
+                helper_instance.init_script(path=args.create[1], runtime=args.create[2])
+            elif args.create[0] == "project":
+                helper_instance.init_project(
+                    path=args.create[1], runtime=args.create[2]
+                )
         else:
             sys.exit(args.create[0] + " is not a valid type")
+    elif args.append_license:
+        helper_instance.list_workflows()
     elif args.list_workflows:
-        config_helper_instance.list_workflows()
+        helper_instance.list_workflows()
     elif args.add_workflow:
-        config_helper_instance.add_workflow()
+        helper_instance.add_workflow()
     elif args.delete_workflow != None and len(args.delete_workflow) >= 1:
-        config_helper_instance.delete_workflow(args.delete_workflow)
+        helper_instance.delete_workflow(args.delete_workflow)
     elif len(sys.argv) == 1:
         parser.print_help(sys.stderr)
         sys.exit(1)

--- a/ptool
+++ b/ptool
@@ -11,59 +11,61 @@ import shlex
 import subprocess
 import sys
 
-config_dir = os.path.join(
-    os.environ["HOME"],
-    "AppData\\Local\\ptool" if platform.system() == "Windows" else ".config/ptool",
+
+parser = argparse.ArgumentParser()
+# ptool -c <script/project> <name/path> <lang>
+parser.add_argument("-c", "--create", metavar="N", nargs=3)
+parser.add_argument("-al", "--append-license", type=str, nargs=1)
+parser.add_argument("-aw", "--add-workflow", action="store_true")
+parser.add_argument(
+    "-dw", "--delete-workflow", default=None, type=str, metavar="<workflow_name>"
 )
-config_path = os.path.join(config_dir, "ptool.config.json")
-configuration = None
-
-if os.path.isfile(config_path):
-    configuration = json.load(open(config_path, "r"))
-else:
-    sys.exit(f"Config at path: {config_path} doesn't exist")
-
-
-def arguments():
-    parser = argparse.ArgumentParser()
-    # ptool -c <script/project> <name/path> <lang>
-    parser.add_argument("-c", "--create", type=str, nargs=3)
-    parser.add_argument("-il", "--license", type=str, nargs=2)
-    return parser.parse_args()
+parser.add_argument("-lw", "--list-workflows", action="store_true")
 
 
 class Helper:
-    def __init__(self, path, language):
-        self.path = os.path.realpath(path)
+    def __init__(self, path: str, language: str, config: dict):
+        self.path = os.path.abspath(path)
         self.lang = language
 
-    def __mkdircd(self) -> NoReturn:
+        self.config_dir = os.path.join(
+            os.environ["HOME"],
+            "AppData\\Local\\ptool"
+            if platform.system() == "Windows"
+            else ".config/ptool",
+        )
+        self.config_fpath = os.path.join(self.config_dir, "ptool.config.json")
+
+        if not os.path.exists(self.config_dir):
+            os.mkdir(self.config_dir)
+
+        if not os.path.exists(self.config_fpath):
+            with open(self.config_fpath, "w") as conf:
+                conf.write(json.dumps({"workflows": ""}, indent=4))
+
+        self.configuration = json.load(open(self.config_fpath, "r"))
+
+    def __mkdircd__(self) -> NoReturn:
         os.mkdir(self.path)
         os.chdir(self.path)
 
-    def __is_lang_valid(self, type: int):
+    def __isvalid__(self, type: int):
+        configuration = self.configuration
         # type 1 is create_script, type 2 is project
-        for language in configuration["languages"]:
-            if self.lang == language["language"] or self.lang == language["alias"]:
+        for workflow in configuration["workflows"]:
+            if self.lang == workflow["name"] or self.lang == workflow["alias"]:
                 if type == 1:
-                    return True, language["language"], language["runtime"]
+                    return True, workflow["name"], workflow["runtime"]
                 elif type == 2:
-                    return True, language["language"], language["commands"]
+                    return True, workflow["name"], workflow["commands"]
 
-    def append_license(self) -> NoReturn:
-        if os.path.exists(self.path) == True:
-            if os.path.isfile(self.path) == True and os.path.isdir(self.path) != True:
-                print("Appending license indentifier")
-                with open(self.path, "w") as script:
-                    print(script.readlines())
-            else:
-                sys.exit(self.path + " is a directory, not a file")
-        else:
-            sys.exit(f"{self.path} doesn't exist")
+    def __write_config__(self, new_config: dict):
+        with open(self.config_fpath, "w") as conf:
+            conf.write(json.dumps(new_config, indent=4))
 
     def init_script(self) -> NoReturn:
         print("Creating new script")
-        lang_valid, language, runtime = self.__is_lang_valid(type=1)
+        lang_valid, language, runtime = self.__isvalid__(type=1)
         if lang_valid:
             with open(self.path, "w") as script:
                 shebang = f"#!/usr/bin/env {runtime}"
@@ -73,33 +75,77 @@ class Helper:
 
     def init_project(self) -> NoReturn:
         print("Creating new script")
-        lang_valid, language, language_commands = self.__is_lang_valid(type=2)
+        lang_valid, language, language_commands = self.__isvalid__(type=2)
         if lang_valid:
             print("Initiating new project in " + self.path)
-            self.__mkdircd()
+            self.__mkdircd__()
             for command in language_commands:
                 subprocess.run(shlex.split(command))
+
+    def list_workflows(self):
+        for workflow in self.configuration["workflows"]:
+            print(workflow["name"])
+
+    def add_workflow(self):
+        conf = self.configuration
+        workflows = conf["workflows"]
+        workflow_name = input("Enter workflow name: ")
+        workflow_alias = input("Alias workflow an alias (Leave it empty if not): ")
+        workflow_commands = list()
+        while True:
+            command = input("Enter new command (Leave empty to exit): ")
+            if len(command) >= 1:
+                workflow_commands.append(command)
+            else:
+                break
+        workflows.append(
+            {
+                "name": workflow_name,
+                "alias": workflow_alias,
+                "commands": workflow_commands,
+            }
+        )
+        conf["workflows"] = workflows
+        self.__write_config__(new_config=conf)
+
+    def delete_workflow(self, name: str):
+        conf = self.configuration
+        workflows = conf["workflows"]
+        names = [wf["name"] for wf in workflows]
+        if name in names:
+            workflows.pop(names.index(name))
+        else:
+            print(
+                name + " not a valid workflow. Run ptool -lw to see existing workflows."
+            )
+        conf["workflows"] = workflows
+        self.__write_config__(new_config=conf)
 
 
 def main():
     types = ["script", "project"]
-    args = arguments()
+    args = parser.parse_args()
+    config_helper_instance = ConfigHelper()
+    config = ConfigHelper().read_config()
     if args.create != None and len(args.create) <= 3:
         c_type, c_path, c_lang = args.create[0], args.create[1], args.create[2]
         if args.create[0] in types:
+            helper_instance = Helper(path=c_path, language=c_lang, config=config)
             if c_type == "script":
-                Helper(path=c_path, language=c_lang).init_script()
+                helper_instance.init_script()
             elif c_type == "project":
-                Helper(path=c_path, language=c_lang).init_project()
-
-            if args.license:
-                Helper(path=c_path, language=c_lang).append_license()
+                helper_instance.init_project()
         else:
-            sys.exit(f"{args.create[0]} is not a valid type")
-    else:
-        sys.exit(
-            "Not enough arguments passed.\nExample usage: ptool --create project hello"
-        )
+            sys.exit(args.create[0] + " is not a valid type")
+    elif args.list_workflows:
+        config_helper_instance.list_workflows()
+    elif args.add_workflow:
+        config_helper_instance.add_workflow()
+    elif args.delete_workflow != None and len(args.delete_workflow) >= 1:
+        config_helper_instance.delete_workflow(args.delete_workflow)
+    elif len(sys.argv) == 1:
+        parser.print_help(sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/ptool
+++ b/ptool
@@ -50,26 +50,6 @@ class Helper:
         with open(self.config_fpath, "w") as conf:
             conf.write(json.dumps(new_config, indent=4))
 
-    def init_script(self, path: str, runtime: str) -> NoReturn:
-        path = os.path.abspath(path)
-        print("Creating new script")
-        with open(self.path, "w") as script:
-            shebang = f"#!/usr/bin/env {runtime}"
-            script.write(shebang)
-            script.close()
-        print("Created script skeleton at " + self.path)
-
-    def init_project(self, path: str, workflow: str) -> NoReturn:
-        print("Creating new script")
-        configuration = self.configuration
-        # type 1 is create_script, type 2 is project
-        for workflow in configuration["workflows"]:
-            if workflow == workflow["name"] or workflow == workflow["alias"]:
-                print("Initiating new project in " + self.path)
-                self.__mkdircd__(path)
-                for command in workflow["commands"]:
-                    subprocess.run(shlex.split(command))
-
     def list_workflows(self):
         for workflow in self.configuration["workflows"]:
             print(workflow["name"])
@@ -79,6 +59,9 @@ class Helper:
         workflows = conf["workflows"]
         workflow_name = input("Enter workflow name: ")
         workflow_alias = input("Alias workflow an alias (Leave it empty if not): ")
+        workflow_extends = input(
+            "Does this workflow extend a pre-existing workflow? (Leave it empty if not): "
+        )
         workflow_commands = list()
         while True:
             command = input("Enter new command (Leave empty to exit): ")
@@ -90,6 +73,7 @@ class Helper:
             {
                 "name": workflow_name,
                 "alias": workflow_alias,
+                "extends": workflow_extends,
                 "commands": workflow_commands,
             }
         )
@@ -109,21 +93,48 @@ class Helper:
         conf["workflows"] = workflows
         self.__write_config__(new_config=conf)
 
+    def init_script(self, path: str, runtime: str) -> NoReturn:
+        path = os.path.abspath(path)
+        with open(self.path, "w") as script:
+            shebang = f"#!/usr/bin/env {runtime}"
+            script.write(shebang)
+            script.close()
+        print("Created script skeleton at " + self.path)
+
+    def init_project(self, path: str, workflow: str) -> NoReturn:
+        path = os.path.abspath(path)
+        configuration = self.configuration
+        names = [wf["name"] for wf in configuration["workflows"]]
+
+        self.__mkdircd__(path)
+        if workflow in names:
+            wf = configuration["workflows"][names.index(workflow)]
+            try:
+                if wf["extends"] in names:
+                    for command in configuration["workflows"][
+                        names.index(wf["extends"])
+                    ]["commands"]:
+                        subprocess.run(shlex.split(command))
+            except:
+                pass
+
+            print("Initiating new project in " + path)
+            for command in wf["commands"]:
+                subprocess.run(shlex.split(command))
+
 
 def main():
-    types = ["script", "project"]
     args = parser.parse_args()
     helper_instance = Helper()
     if args.create != None and len(args.create) <= 3:
-        if args.create[0] in types:
-            if args.create[0] == "script":
-                helper_instance.init_script(path=args.create[1], runtime=args.create[2])
-            elif args.create[0] == "project":
-                helper_instance.init_project(
-                    path=args.create[1], runtime=args.create[2]
-                )
+        if args.create[0] == "script":
+            helper_instance.init_script(path=args.create[2], runtime=args.create[1])
+        elif args.create[0] == "project":
+            helper_instance.init_project(path=args.create[2], workflow=args.create[1])
         else:
-            sys.exit(args.create[0] + " is not a valid type")
+            sys.exit(
+                args.create[0] + "is not a valid type. Valid types: project, script"
+            )
     elif args.append_license:
         helper_instance.list_workflows()
     elif args.list_workflows:


### PR DESCRIPTION
Currently we instantiate Helper before looking for arg matches. In the case
--create is passed to the script we overwrite the helper object with one that is being
passed workflow and path values.

I'm not sure if passing c_path and c_workflow to each method instead of the constructor
that is called when an argparse argument is passed is a better way of doing it.
