### PR TITLE
Better argument handling

### DIFF
--- a/ptool
+++ b/ptool
@@ -9,14 +9,21 @@ import shutil
 import sys
 
 parser = argparse.ArgumentParser()
-# ptool -c <script/project> <name/path> <lang>
-parser.add_argument("-c", "--create", metavar="N", nargs=3)
-parser.add_argument("-al", "--append-license", type=str, nargs=1)
-parser.add_argument("-aw", "--add-workflow", action="store_true")
+parser.add_argument("-c", "--create", action="store_true")
 parser.add_argument(
-    "-dw", "--delete-workflow", default=None, type=str, metavar="<workflow_name>"
+    "-w",
+    "--workflow",
+    type="str",
+    default=None,
+    metavar="<workflow>",
+    help="Run --list_workflows to get a list of your workflows.",
 )
-parser.add_argument("-lw", "--list-workflows", action="store_true")
+parser.add_argument("-p", "--path", type="str", default=None)
+parser.add_argument("--add-workflow", action="store_true")
+parser.add_argument(
+    "--delete-workflow", default=None, type=str, metavar="<workflow_name>"
+)
+parser.add_argument("--list-workflows", action="store_true")
 parser.add_argument("--open-config", action="store_true")
 
 config_dir = os.path.join(
@@ -122,26 +129,37 @@ def open_config():
         sys.exit("Please add $EDITOR in your system variables")
 
 
-def init_project(path: str, workflow: str):
-    path = os.path.abspath(path)
+def exec_workflow(path: str, workflow: str):
+    fpath = os.path.abspath(".") if path is None else os.path.abspath(path)
+
+    if path is not None:
+        mkdircd(fpath)
+
+    print("Current path: " + fpath)
+
     names = (
         [wf["name"] for wf in configuration["workflows"]]
         if len(configuration["workflows"]) >= 1
-        else sys.exit(1)
+        else sys.exit(
+            "Specify correct workflow. Use ptool --list-workflows to get a list of your workflows"
+        )
     )
-    mkdircd(path)
+
     if workflow in names:
         wf = configuration["workflows"][names.index(workflow)]
-        print("Initiating new project in " + path)
-        try:
-            if wf["extends"] in names:
-                print("Running " + wf["extends"] + " commands!")
-                for command in configuration["workflows"][names.index(wf["extends"])][
-                    "commands"
-                ]:
-                    os.system(command)
-        except:
-            pass
+
+        print("Initiating new project in " + fpath)
+
+        if path is not None:
+            try:
+                if wf["extends"] in names:
+                    print("Running " + wf["extends"] + " commands!")
+                    for command in configuration["workflows"][
+                        names.index(wf["extends"])
+                    ]["commands"]:
+                        os.system(command)
+            except:
+                pass
 
         print("Running " + wf["name"] + " commands!")
         for command in wf["commands"]:
@@ -152,13 +170,11 @@ def init_project(path: str, workflow: str):
 
 def main():
     args = parser.parse_args()
-    if args.create != None and len(args.create) <= 3:
-        if args.create[0] == "project":
-            init_project(path=args.create[2], workflow=args.create[1])
+    if args.create:
+        if args.workflow is None:
+            sys.exit("Please specify workflow")
         else:
-            sys.exit(
-                args.create[0] + "is not a valid type. Valid types: project, script",
-            )
+            exec_workflow(path=args.path, workflow=args.workflow)
     elif args.list_workflows:
         list_workflows()
     elif args.add_workflow:

--- a/ptool
+++ b/ptool
@@ -13,15 +13,14 @@ parser.add_argument("-c", "--create", action="store_true")
 parser.add_argument(
     "-w",
     "--workflow",
-    type="str",
-    default=None,
-    metavar="<workflow>",
+    type=str,
+    metavar="workflow",
     help="Run --list_workflows to get a list of your workflows.",
 )
-parser.add_argument("-p", "--path", type="str", default=None)
+parser.add_argument("-p", "--path", type=str, default=None)
 parser.add_argument("--add-workflow", action="store_true")
 parser.add_argument(
-    "--delete-workflow", default=None, type=str, metavar="<workflow_name>"
+    "--delete-workflow", type=str, default=None, metavar="workflow",
 )
 parser.add_argument("--list-workflows", action="store_true")
 parser.add_argument("--open-config", action="store_true")
@@ -91,7 +90,7 @@ def add_workflow():
 
     if len(configuration["workflows"]) >= 1:
         new_workflow["extends"] = input(
-            "Does this workflow extend a pre-existing workflow? (Leave it empty if not): "
+            "Does this workflow extend a pre-existing workflow? (Leave it empty if not): ",
         )
     else:
         new_workflow["extends"] = ""
@@ -141,7 +140,7 @@ def exec_workflow(path: str, workflow: str):
         [wf["name"] for wf in configuration["workflows"]]
         if len(configuration["workflows"]) >= 1
         else sys.exit(
-            "Specify correct workflow. Use ptool --list-workflows to get a list of your workflows"
+            "Specify correct workflow. Use ptool --list-workflows to get a list of your workflows",
         )
     )
 
@@ -150,22 +149,23 @@ def exec_workflow(path: str, workflow: str):
 
         print("Initiating new project in " + fpath)
 
-        if path is not None:
-            try:
-                if wf["extends"] in names:
-                    print("Running " + wf["extends"] + " commands!")
-                    for command in configuration["workflows"][
-                        names.index(wf["extends"])
-                    ]["commands"]:
-                        os.system(command)
-            except:
-                pass
+        try:
+            if wf["extends"] in names:
+                print("Running " + wf["extends"] + " commands!")
+                for command in configuration["workflows"][names.index(wf["extends"])][
+                    "commands"
+                ]:
+                    os.system(command)
+        except:
+            pass
 
         print("Running " + wf["name"] + " commands!")
         for command in wf["commands"]:
             os.system(command)
 
         print("Done 🎉")
+    else:
+        sys.exit(workflow + " is invalid.")
 
 
 def main():


### PR DESCRIPTION
- Separated --create which used to take 3 arguments as --create <project> <workflow> <path>
  to now take no values. To specify a workflow use --workflow <workflow-name>, this is mandatory.
  To specify project path use --path <relative/abs path>.
- --path takes the default value of None in which case the commands of the workflow will be run in
  in the folder ptool is being called from. This in effect let's us "extend" pre-existing projects.
  An example is adding typescript support packages to JavaScript project.
